### PR TITLE
Keep track of round_robin indices, sort ips, shift by index

### DIFF
--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -3,7 +3,6 @@ use std::net::{
     SocketAddr,
     SocketAddrV4, SocketAddrV6,
 };
-use std::vec;
 use c_ares::AResults;
 
 mod c_ares;
@@ -11,36 +10,100 @@ mod c_ares;
 pub use self::c_ares::GLOBAL_RESOLVER;
 
 pub struct IpAddrs {
-    iter: vec::IntoIter<SocketAddr>,
+    inner: SingleOrShifted<SocketAddr>,
 }
 
 impl IpAddrs {
-    pub fn new(port: u16, a_results: AResults) -> IpAddrs {
-        let ips = a_results.iter().map(|res| {
-            SocketAddr::V4(SocketAddrV4::new(res.ipv4(), port))
+    pub fn new(port: u16, a_results: AResults, index: usize) -> IpAddrs {
+        // Sort list by ips returned, we need a set ordering for the round-robin
+        // selection of ips to work correctly.
+        let mut ips = a_results.iter().map(|res| res.ipv4()).collect::<Vec<_>>();
+        ips.sort();
+
+        let ips = ips.into_iter().map(|ip| {
+            Some(SocketAddr::V4(SocketAddrV4::new(ip, port)))
         }).collect::<Vec<_>>();
+
         IpAddrs {
-            iter: ips.into_iter(),
+            inner: SingleOrShifted::ShiftedVec(ips, index),
         }
     }
 
     pub fn try_parse(host: &str, port: u16) -> Option<IpAddrs> {
         if let Ok(addr) = host.parse::<Ipv4Addr>() {
             let addr = SocketAddrV4::new(addr, port);
-            return Some(IpAddrs { iter: vec![SocketAddr::V4(addr)].into_iter() })
+            return Some(IpAddrs {
+                inner: SingleOrShifted::Single(Some(SocketAddr::V4(addr))),
+            })
         }
+
         if let Ok(addr) = host.parse::<Ipv6Addr>() {
             let addr = SocketAddrV6::new(addr, port, 0, 0);
-            return Some(IpAddrs { iter: vec![SocketAddr::V6(addr)].into_iter() })
+            return Some(IpAddrs {
+                inner: SingleOrShifted::Single(Some(SocketAddr::V6(addr))),
+            })
         }
+
         None
     }
 }
 
 impl Iterator for IpAddrs {
     type Item = SocketAddr;
+
     #[inline]
-    fn next(&mut self) -> Option<SocketAddr> {
-        self.iter.next()
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+enum SingleOrShifted<T> {
+    Single(Option<T>),
+    ShiftedVec(Vec<Option<T>>, usize),
+}
+
+impl<T> Iterator for SingleOrShifted<T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<T> {
+        match self {
+            SingleOrShifted::Single(ref mut item) => {
+                item.take()
+            },
+            SingleOrShifted::ShiftedVec(ref mut items, ref mut index) => {
+                let len = items.len();
+                let ret = items[*index % len].take();
+                *index += 1;
+                ret
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_or_shifted_single_works() {
+        let mut a = SingleOrShifted::Single(Some(10));
+        assert_eq!(Some(10), a.next());
+        assert_eq!(None, a.next());
+    }
+
+    #[test]
+    fn single_or_shifted_shifted_works() {
+        let mut a = SingleOrShifted::ShiftedVec(vec![Some(10), Some(20), Some(30)], 0);
+        assert_eq!(Some(10), a.next());
+        assert_eq!(Some(20), a.next());
+        assert_eq!(Some(30), a.next());
+        assert_eq!(None, a.next());
+
+        let mut b = SingleOrShifted::ShiftedVec(vec![Some(10), Some(20), Some(30)], 2);
+        assert_eq!(Some(30), b.next());
+        assert_eq!(Some(10), b.next());
+        assert_eq!(Some(20), b.next());
+        assert_eq!(None, b.next());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ impl Future for HttpConnecting {
                         Async::NotReady => return Ok(Async::NotReady),
                         Async::Ready(a_results) => {
                             let shift_index = *self.round_robin_map.entry(host)
-                                .and_modify(|e| { *e += 1 })
+                                .and_modify(|e| { *e = e.overflowing_add(1).0 })
                                 .or_insert(0);
 
                             State::Connecting(ConnectingTcp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ use c_ares::AResults;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::mem;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
@@ -213,7 +212,7 @@ impl Connect for HttpConnector {
         };
 
         HttpConnecting {
-            state: State::Lazy(self.executor.clone(), host.into(), port, self.local_address),
+            state: State::Lazy(self.executor.clone(), Arc::new(host.into()), port, self.local_address),
             handle: self.handle.clone(),
             keep_alive_timeout: self.keep_alive_timeout,
             nodelay: self.nodelay,
@@ -263,13 +262,12 @@ pub struct HttpConnecting {
     keep_alive_timeout: Option<Duration>,
     nodelay: bool,
 
-    round_robin_map: HashMap<String, usize>,
+    round_robin_map: HashMap<Arc<String>, usize>,
 }
 
 enum State {
-    Uninitialized,
-    Lazy(HttpConnectExecutor, String, u16, Option<IpAddr>),
-    Resolving(oneshot::SpawnHandle<AResults, c_ares::Error>, String, u16, Option<IpAddr>),
+    Lazy(HttpConnectExecutor, Arc<String>, u16, Option<IpAddr>),
+    Resolving(oneshot::SpawnHandle<AResults, c_ares::Error>, Arc<String>, u16, Option<IpAddr>),
     Connecting(ConnectingTcp),
     Error(Option<io::Error>),
 }
@@ -280,29 +278,28 @@ impl Future for HttpConnecting {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         loop {
-            self.state = match mem::replace(&mut self.state, State::Uninitialized) {
-                State::Uninitialized => panic!("Should not be State::Uninitialized!"),
-                State::Lazy(executor, host, port, local_addr) => {
+            let state = match self.state {
+                State::Lazy(ref executor, ref host, port, local_addr) => {
                     // If the host is already an IP addr (v4 or v6),
                     // skip resolving the dns and start connecting right away.
-                    if let Some(addrs) = dns::IpAddrs::try_parse(&host, port) {
+                    if let Some(addrs) = dns::IpAddrs::try_parse(host, port) {
                         State::Connecting(ConnectingTcp {
                             addrs,
                             local_addr,
                             current: None
                         })
                     } else {
-                        let work = GLOBAL_RESOLVER.query_a(&host);
-                        State::Resolving(oneshot::spawn(work, &executor), host, port, local_addr)
+                        let work = GLOBAL_RESOLVER.query_a(host);
+                        State::Resolving(oneshot::spawn(work, executor), Arc::clone(host), port, local_addr)
                     }
                 },
-                State::Resolving(mut future, host, port, local_addr) => {
+                State::Resolving(ref mut future, ref host, port, local_addr) => {
                     match future.poll()
                         .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
                     {
                         Async::NotReady => return Ok(Async::NotReady),
                         Async::Ready(a_results) => {
-                            let shift_index = *self.round_robin_map.entry(host)
+                            let shift_index = *self.round_robin_map.entry(Arc::clone(host))
                                 .and_modify(|e| { *e = e.overflowing_add(1).0 })
                                 .or_insert(0);
 
@@ -327,7 +324,8 @@ impl Future for HttpConnecting {
                     return Ok(Async::Ready((sock, Connected::new())));
                 }
                 State::Error(ref mut e) => return Err(e.take().expect("polled more than once")),
-            }
+            };
+            self.state = state;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ use c_ares_resolver::CAresFuture;
 use c_ares::AResults;
 
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::mem;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
@@ -215,6 +217,7 @@ impl Connect for HttpConnector {
             handle: self.handle.clone(),
             keep_alive_timeout: self.keep_alive_timeout,
             nodelay: self.nodelay,
+            round_robin_map: HashMap::new(),
         }
     }
 }
@@ -226,6 +229,7 @@ fn invalid_url(err: InvalidUrl, handle: &Option<Handle>) -> HttpConnecting {
         handle: handle.clone(),
         keep_alive_timeout: None,
         nodelay: false,
+        round_robin_map: HashMap::new(),
     }
 }
 
@@ -258,11 +262,14 @@ pub struct HttpConnecting {
     handle: Option<Handle>,
     keep_alive_timeout: Option<Duration>,
     nodelay: bool,
+
+    round_robin_map: HashMap<String, usize>,
 }
 
 enum State {
+    Uninitialized,
     Lazy(HttpConnectExecutor, String, u16, Option<IpAddr>),
-    Resolving(oneshot::SpawnHandle<AResults, c_ares::Error>, u16, Option<IpAddr>),
+    Resolving(oneshot::SpawnHandle<AResults, c_ares::Error>, String, u16, Option<IpAddr>),
     Connecting(ConnectingTcp),
     Error(Option<io::Error>),
 }
@@ -273,35 +280,39 @@ impl Future for HttpConnecting {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         loop {
-            let state;
-            match self.state {
-                State::Lazy(ref executor, ref mut host, port, local_addr) => {
+            self.state = match mem::replace(&mut self.state, State::Uninitialized) {
+                State::Uninitialized => panic!("Should not be State::Uninitialized!"),
+                State::Lazy(executor, host, port, local_addr) => {
                     // If the host is already an IP addr (v4 or v6),
                     // skip resolving the dns and start connecting right away.
-                    if let Some(addrs) = dns::IpAddrs::try_parse(host, port) {
-                        state = State::Connecting(ConnectingTcp {
+                    if let Some(addrs) = dns::IpAddrs::try_parse(&host, port) {
+                        State::Connecting(ConnectingTcp {
                             addrs,
                             local_addr,
                             current: None
                         })
                     } else {
                         let work = GLOBAL_RESOLVER.query_a(&host);
-                        state = State::Resolving(oneshot::spawn(work, executor), port, local_addr);
+                        State::Resolving(oneshot::spawn(work, &executor), host, port, local_addr)
                     }
                 },
-                State::Resolving(ref mut future, port, local_addr) => {
+                State::Resolving(mut future, host, port, local_addr) => {
                     match future.poll()
                         .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
                     {
                         Async::NotReady => return Ok(Async::NotReady),
                         Async::Ready(a_results) => {
-                            state = State::Connecting(ConnectingTcp {
-                                addrs: dns::IpAddrs::new(port, a_results),
+                            let shift_index = *self.round_robin_map.entry(host)
+                                .and_modify(|e| { *e += 1 })
+                                .or_insert(0);
+
+                            State::Connecting(ConnectingTcp {
+                                addrs: dns::IpAddrs::new(port, a_results, shift_index),
                                 local_addr,
                                 current: None,
                             })
                         }
-                    };
+                    }
                 }
                 State::Connecting(ref mut c) => {
                     let sock = try_ready!(c.poll(&self.handle));
@@ -317,7 +328,6 @@ impl Future for HttpConnecting {
                 }
                 State::Error(ref mut e) => return Err(e.take().expect("polled more than once")),
             }
-            self.state = state;
         }
     }
 }


### PR DESCRIPTION
We want to use round-robin ordering In order to balance out load between different servers returned by the DNS request. 

In order to do so, I added a HashMap of indices by host strings on the connector. The connector passes this index to the ToAddrs type so that it can shift the Vec<IpAddrs> appropriately.